### PR TITLE
Test sinatra base gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@ source 'https://rubygems.org'
 
 ruby "2.5.1"
 
-gem "sinatra"
+gem "sinatra-base"
+# if specify: , "~> 1.4" it will work when running rackup -p 4567 however will only do so with: warning: constant ::Fixnum is deprecated
 gem "slim"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    mustermann (1.0.3)
     rack (2.0.5)
-    rack-protection (2.0.4)
-      rack
-    sinatra (2.0.4)
-      mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.4)
-      tilt (~> 2.0)
+    sinatra-base (1.0)
+      rack (>= 1.0)
     slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -20,7 +14,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  sinatra
+  sinatra-base
   slim
 
 RUBY VERSION


### PR DESCRIPTION
As currently, error:
> cannot load such file -- rack/showexceptions (LoadError)

(as in Gemfile comment), if the sinatra-base gem is specified to ~>1.4 it will run, however with a warning:
> warning: constant ::Fixnum is deprecated

When as in master it is just the sinatra gem and therefore using a newer version of rack etc (2.0.5) this works fine.

